### PR TITLE
Few touchups to the Docker Compose Update PR

### DIFF
--- a/astro/src/content/docs/get-started/download-and-install/docker.mdx
+++ b/astro/src/content/docs/get-started/download-and-install/docker.mdx
@@ -21,7 +21,7 @@ The following example is using Docker Compose. Here are [kubernetes installation
 
 All of the FusionAuth Docker images may be found on [Docker Hub](https://hub.docker.com/u/fusionauth/).
 
-The FusionAuth Docker Compose yaml files may be found on [FusionAuth containers repository](https://github.com/FusionAuth/fusionauth-containers) and more examples in the [FusionAuth docker compose example repository](https://github.com/FusionAuth/fusionauth-example-docker-compose) described in more detail below.
+The FusionAuth Docker Compose yaml files may be found on [FusionAuth containers repository](https://github.com/FusionAuth/fusionauth-containers) and more examples in the [FusionAuth Docker Compose example repository](https://github.com/FusionAuth/fusionauth-example-docker-compose) described in more detail below.
 
 If you're looking for a complete configuration to get up and running quickly, use our Docker Compose example. `docker-compose.yml` will install FusionAuth with OpenSearch, but you can [switch between the different search engines](/docs/lifecycle/manage-users/search/switch-search-engines/).
 
@@ -139,15 +139,15 @@ If you want to build your own image starting with our base image, start with the
 
 <RemoteCode title="Example docker-compose.yml for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/docker-compose.yml" lang="yaml" />
 
-<RemoteCode title="Example Dockerfile for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/fusionauth-app/Dockerfile" lang="yaml" />
+<RemoteCode title="Example Dockerfile for building fusionauth-app including a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/build/fusionauth-app/Dockerfile" lang="docker" />
 
-With this example can use `docker compose build` to only run the build steps in the referenced Dockerfile. This will create you a custom Docker image which is consequentially used in the creation of the container in Docker Compose when running `docker compose up -d`. Alternatively you can run only `docker compose up -d` which will automatically take care of the build as well if not present.
+With this example, you can use `docker compose build` to only run the build steps in the referenced Dockerfile. This will create you a custom Docker image which is consequentially used in the creation of the container in Docker Compose when running `docker compose up -d`. Alternatively you can run only `docker compose up -d` which will automatically take care of the build as well if not present.
 
 By default the build process will cache a lot of the steps, to force a fresh build you can run `docker compose build --pull --no-cache` instead.
 
 Here's the FusionAuth application Dockerfile as a reference which builds the `fusionauth/fusionauth-app` base image.
 
-<RemoteCode title="The FusionAuth Docker file" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/fusionauth-app/Dockerfile" lang="yaml" />
+<RemoteCode title="The FusionAuth Docker file" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/fusionauth-app/Dockerfile" lang="docker" />
 
 Here is [additional Docker documentation](https://docs.docker.com/engine/reference/builder/#from).
 
@@ -176,7 +176,7 @@ The following is an example `docker-compose.yml` file configuring FusionAuth to 
 
 <RemoteCode title="Example docker-compose.yml for running Kickstart" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/kickstart/docker-compose.yml" lang="yaml" />
 
-After running `docker compose up -d` you should see a line similar to the one below in the logs. These logs can be accessed using this command: `docker compose logs fusionauth`:
+After running `docker compose up -d` you should see a line similar to the one below in the logs. These logs can be accessed using this command: `docker compose logs -f fusionauth`:
 
 ```plaintext title="FusionAuth log messages indicating Kickstart has succeeded"
 io.fusionauth.api.service.system.kickstart.KickstartRunner - Summary
@@ -210,7 +210,7 @@ The following is an example `docker-compose.yml` file configuring FusionAuth to 
 
 <RemoteCode title="Example docker-compose.yml for installing a plugin" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-example-docker-compose/main/plugin/docker-compose.yml" lang="yaml" />
 
-After running `docker compose up -d` you should see a line like this in the logs, which you can access using the command `docker compose logs fusionauth`:
+After running `docker compose up -d` you should see a line like this in the logs, which you can access using the command `docker compose logs -f fusionauth`:
 
 ```plaintext title="FusionAuth log messages indicating a plugin has been successfully installed"
 INFO  io.fusionauth.api.plugin.guice.PluginModule - Installing plugin [com.mycompany.fusionauth.plugins.guice.MyExampleFusionAuthPluginModule]
@@ -236,7 +236,7 @@ Modifying the FusionAuth service in `docker-compose.yml` to use other Docker net
 
 ## OpenSearch Production Deployment Configuration
 
-Production runtime requirements and configuration for OpenSearch will drastically differ from the docker compose examples as the examples are configured without any security or redundancy.
+Production runtime requirements and configuration for OpenSearch will drastically differ from the Docker Compose examples as the examples are configured without any security or redundancy.
 
 Please review the [Installing OpenSearch documentation](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/) for further details around production deployment.
 
@@ -261,4 +261,4 @@ Due to Oracle licensing restrictions, the docker images published on [Docker Hub
 
 If you wish to use MySQL, you'll need to build a custom container that includes the MySQL Connector JAR file. Here is an example container definition that uses the FusionAuth image as a base layer and adds the MySQL connector.
 
-<RemoteCode title="Example Dockerfile which downloads the MySQL connector" lang="yaml" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/fusionauth-app-mysql/Dockerfile" />
+<RemoteCode title="Example Dockerfile which downloads the MySQL connector" lang="docker" url="https://raw.githubusercontent.com/FusionAuth/fusionauth-containers/master/docker/fusionauth/fusionauth-app-mysql/Dockerfile" />


### PR DESCRIPTION
- Changing Dockerfile code syntax
- Using "Docker Compose" instead of "docker compose" in some places
- Adding `-f` to `docker compose logs`